### PR TITLE
Fix localization strings + add ru_ru.json

### DIFF
--- a/common/src/main/resources/assets/draggable_lists/lang/en_us.json
+++ b/common/src/main/resources/assets/draggable_lists/lang/en_us.json
@@ -1,7 +1,7 @@
 {
-  "text.autoconfig.draggable.title": "Draggable",
-  "text.autoconfig.draggable.option.disableResourcePackArrows": "Disable Resource Pack Arrows",
-  "text.autoconfig.draggable.option.disableDatapackArrows": "Disable Datapack Arrows",
-  "text.autoconfig.draggable.option.disableServerArrows": "Disable Server Arrows",
-  "text.autoconfig.draggable.option.disableLevelArrows": "Disable Level Arrows"
+  "text.autoconfig.draggable_lists.title": "Draggable",
+  "text.autoconfig.draggable_lists.option.disableResourcePackArrows": "Disable Resource Pack Arrows",
+  "text.autoconfig.draggable_lists.option.disableDatapackArrows": "Disable Datapack Arrows",
+  "text.autoconfig.draggable_lists.option.disableServerArrows": "Disable Server Arrows",
+  "text.autoconfig.draggable_lists.option.disableLevelArrows": "Disable Level Arrows"
 }

--- a/common/src/main/resources/assets/draggable_lists/lang/ru_ru.json
+++ b/common/src/main/resources/assets/draggable_lists/lang/ru_ru.json
@@ -1,0 +1,9 @@
+{
+  "text.autoconfig.draggable_lists.title": "Настройки Draggable Lists",
+  "text.autoconfig.draggable_lists.option.disableResourcePackArrows": "Убрать стрелки перемещения наборов ресурсов",
+  "text.autoconfig.draggable_lists.option.disableDatapackArrows": "Убрать стрелки перемещения наборов данных",
+  "text.autoconfig.draggable_lists.option.disableServerArrows": "Убрать стрелки перемещения серверов",
+  "text.autoconfig.draggable_lists.option.disableLevelArrows": "Убрать стрелки перемещения миров",
+  "modmenu.summaryTranslation.draggable_lists": "Перетаскивание миров, серверов, наборов ресурсов и данных.",
+  "modmenu.descriptionTranslation.draggable_lists": "Draggable Lists добавляет возможность перетаскивать миры, серверы и наборы ресурсов и данных, потому что... кто любит постоянно целиться по маленьким стрелочкам? Просто перетащите элемент в списке!"
+}


### PR DESCRIPTION
Just fixed invalid keys. Also translation uses description from Modrinth as a base text in the ModMenu description field. Summary has been taken from the mod itself

Btw, configuration screen is a bit broken too, there are no settings for worlds and datapacks